### PR TITLE
`wayland/scanner`: `reset` + `destructor` handling

### DIFF
--- a/modules/wayland/scanner.scm
+++ b/modules/wayland/scanner.scm
@@ -119,6 +119,11 @@
                                      (and arg-interface-type
                                           (_->- arg-interface-type))
                                      (->bool allow-null)) ...)))
+    ((request (@ (name ,name) (type (,type #f))))
+     (%make-message (_->- name)
+                    (and type (string=? type "destructor"))
+                    #f 'request
+                    (list '())))
     ((enum (@ (name ,name) (bitfield (,bitfield #f)))
            (entry (@ (name ,entry-name) (value ,entry-value)) . ,rest) ...)
      (%make-enum (_->- name)

--- a/modules/wayland/scanner.scm
+++ b/modules/wayland/scanner.scm
@@ -107,6 +107,12 @@
                                      (and arg-interface-type
                                           (_->- arg-interface-type))
                                      (->bool allow-null)) ...)))
+    ((event (@ (name ,name) (since (,since #f)) (type (,type #f))))
+     (%make-message (_->- name)
+                    (and type (string=? type "destructor"))
+                    since
+                    'event
+                    (list '())))
     ((request (@ (name ,name) (since (,since #f)) (type (,type #f)))
               (arg (@ (type ,arg-type)
                       (name ,(_->- -> arg-name))

--- a/modules/wayland/scanner.scm
+++ b/modules/wayland/scanner.scm
@@ -112,7 +112,7 @@
                     (and type (string=? type "destructor"))
                     since
                     'event
-                    (list '())))
+                    (list)))
     ((request (@ (name ,name) (since (,since #f)) (type (,type #f)))
               (arg (@ (type ,arg-type)
                       (name ,(_->- -> arg-name))
@@ -129,7 +129,7 @@
      (%make-message (_->- name)
                     (and type (string=? type "destructor"))
                     #f 'request
-                    (list '())))
+                    (list)))
     ((enum (@ (name ,name) (bitfield (,bitfield #f)))
            (entry (@ (name ,entry-name) (value ,entry-value)) . ,rest) ...)
      (%make-enum (_->- name)


### PR DESCRIPTION
Some protocols have `destructor` request and `reset` event which were not handled by the previous version.  