### PR TITLE
WIP: scanner: initialize: keep listener callback trampolines alive.

### DIFF
--- a/modules/wayland/scanner.scm
+++ b/modules/wayland/scanner.scm
@@ -361,22 +361,32 @@
                  bs wrap unwrap check (slot-name #:init-keyword keyword) ...)
                (export bs wrap unwrap check cname)
                (define-method (initialize (obj cname) initargs)
-                 (let* ((slot-name
-                         (let ((proc (get-keyword keyword initargs #f)))
-                           (cond ((ffi:pointer? proc) proc)
-                                 ((procedure? proc)
-                                  (ffi:procedure->pointer
-                                   ffi:void
-                                   (lambda lambda-args
-                                     (proc call-args ...))
-                                   (list '* '* ffi-descs ...)))
-                                 ((->bool proc) (throw 'wayland-init-fail keyword proc))
-                                 (else ffi:%null-pointer))))
-                        ...)
-                   (next-method obj (append (list keyword slot-name) ... initargs))
-                   (for-each (lambda (p) (unless (ffi:null-pointer? p) (bs-keep-alive! obj p)))
-                             (list slot-name ...))
-                   obj))))))
+                 (let ((callbacks '()))
+                   (let ((result
+                          (next-method
+                           obj (append (list keyword
+                                     (let ((proc (get-keyword keyword initargs #f)))
+                                       (cond ((ffi:pointer? proc) proc)
+                                             ((procedure? proc)
+                                              (let* ((callback-procedure
+                                                      (lambda lambda-args
+                                                        (proc call-args ...)))
+                                                     (callback
+                                                      (ffi:procedure->pointer
+                                                       ffi:void
+                                                       callback-procedure
+                                                       (list '* '* ffi-descs ...))))
+                                                (set! callbacks
+                                                      (cons callback-procedure
+                                                            (cons callback callbacks)))
+                                                callback))
+                                             ((->bool proc) (throw 'wayland-init-fail keyword proc))
+                                             (else ffi:%null-pointer)))) ...
+                                             initargs))))
+                     (for-each (lambda (callback)
+                                 (bs-keep-alive! obj callback))
+                               callbacks)
+                     result)))))))
     (define (message->procedure-code request iname index type)
       (assert (and (message? request)
                    (eq? (message-type request)

--- a/modules/wayland/scanner.scm
+++ b/modules/wayland/scanner.scm
@@ -361,19 +361,22 @@
                  bs wrap unwrap check (slot-name #:init-keyword keyword) ...)
                (export bs wrap unwrap check cname)
                (define-method (initialize (obj cname) initargs)
-                 (next-method
-                  obj (append (list keyword
-                                    (let ((proc (get-keyword keyword initargs #f)))
-                                      (cond ((ffi:pointer? proc) proc)
-                                            ((procedure? proc)
-                                             (ffi:procedure->pointer
-                                              ffi:void
-                                              (lambda lambda-args
-                                                (proc call-args ...))
-                                              (list '* '* ffi-descs ...)))
-                                            ((->bool proc) (throw 'wayland-init-fail keyword proc))
-                                            (else ffi:%null-pointer)))) ...
-                                            initargs)))))))
+                 (let* ((slot-name
+                         (let ((proc (get-keyword keyword initargs #f)))
+                           (cond ((ffi:pointer? proc) proc)
+                                 ((procedure? proc)
+                                  (ffi:procedure->pointer
+                                   ffi:void
+                                   (lambda lambda-args
+                                     (proc call-args ...))
+                                   (list '* '* ffi-descs ...)))
+                                 ((->bool proc) (throw 'wayland-init-fail keyword proc))
+                                 (else ffi:%null-pointer))))
+                        ...)
+                   (next-method obj (append (list keyword slot-name) ... initargs))
+                   (for-each (lambda (p) (unless (ffi:null-pointer? p) (bs-keep-alive! obj p)))
+                             (list slot-name ...))
+                   obj))))))
     (define (message->procedure-code request iname index type)
       (assert (and (message? request)
                    (eq? (message-type request)


### PR DESCRIPTION
procedure->pointer's returned pointer was discarded right after being embedded (by raw address only) into the listener's C-owned struct. Nothing kept that pointer reachable, so GC could free its trampoline while libwayland still held the address and later dispatched through it -- a dangling-function-pointer segfault on any Wayland/XDG event. Now captures each callback pointer in a temporary, delegates to next-method, then pushes every non-null one onto the listener's %keep-alive slot (bytestructure-class) so it survives as long as the listener instance does.