### PR TITLE
WIP: scanner: fix double-wrap of typed new_id request results.

### DIFF
--- a/modules/wayland/scanner.scm
+++ b/modules/wayland/scanner.scm
@@ -470,21 +470,20 @@
                            ffi-rest-args ...))))
                     (lambda (obj lambda-args ...)
                       (let ((%arg-out
-                             (wrap-wl-proxy
-                              (%wl-proxy-marshal-flags
-                               (#,(->syntax (make-%unwrap-name iname)) obj)
-                               opcode-name
-                               #,@(if ret
-                                      (or (and=> (arg-interface ret)
-                                                 (lambda (x)
-                                                   (with-syntax
-                                                       ((iname (->syntax
-                                                                (make-%interface-name x))))
-                                                     #`((unwrap-wl-interface iname)
-                                                        (wl-proxy-get-version obj)))))
-                                          #'((unwrap-wl-interface %arg-interface) %arg-version))
-                                      (list #`ffi:%null-pointer #`(wl-proxy-get-version obj)))
-                               destructor-flag rest-args ...))))
+                             (%wl-proxy-marshal-flags
+                              (#,(->syntax (make-%unwrap-name iname)) obj)
+                              opcode-name
+                              #,@(if ret
+                                     (or (and=> (arg-interface ret)
+                                                (lambda (x)
+                                                  (with-syntax
+                                                      ((iname (->syntax
+                                                               (make-%interface-name x))))
+                                                    #`((unwrap-wl-interface iname)
+                                                       (wl-proxy-get-version obj)))))
+                                         #'((unwrap-wl-interface %arg-interface) %arg-version))
+                                     (list #`ffi:%null-pointer #`(wl-proxy-get-version obj)))
+                              destructor-flag rest-args ...)))
                         %arg-out
                         #,(if ret
                               (or (and=> (arg-interface ret)
@@ -492,7 +491,7 @@
                                            #`(#,(->syntax
                                                  (make-%wrap-name x))
                                               %arg-out)))
-                                  #'%arg-out)
+                                  #'(wrap-wl-proxy %arg-out))
                               (->syntax *unspecified*))))))))))))
 
     (define (enum->code enum in-name)


### PR DESCRIPTION
Client requests returning a typed new_id (e.g.
wl_display.get_registry) wrapped the marshalled proxy pointer twice: once generically via wrap-wl-proxy when binding %arg-out, then again via the interface-specific wrap-* on return. wrap-*'s underlying wrap closure only accepts a bytestructure, integer, or raw pointer, so it rejected the already-wrapped <bs> instance with "~S is not a pointer or bytestructure, integer" -- breaking every typed new_id request, including wl-display-get-registry itself.

%arg-out now holds the raw wl_proxy_marshal_flags pointer. The typed branch wraps it once via the interface-specific wrap-*; the untyped/generic new_id branch (e.g. wl_registry.bind, which has no static interface to wrap with) now explicitly wraps it once via wrap-wl-proxy instead of relying on %arg-out being pre-wrapped.